### PR TITLE
Reformatted some code, and renamed the option to --plugin-threads. Ex…

### DIFF
--- a/src/wenum/fuzzqueues.py
+++ b/src/wenum/fuzzqueues.py
@@ -368,7 +368,7 @@ class PluginQueue(FuzzListQueue):
                 "No plugin selected, check the --script name or category introduced."
             )
 
-        concurrent = session.options.plugin_executors
+        concurrent = session.options.plugin_threads
         # Creating several PluginExecutors to enable several requests to be processed by plugins simultaneously
         super().__init__(session, [PluginExecutor(session, lplugins) for i in range(concurrent)])
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -155,7 +155,7 @@ class OptionsTest(unittest.TestCase):
              f"--{options.opt_name_header}", "Test3: qweqwe", f"--{options.opt_name_cookie}", "Cookie=123",
              f"--{options.opt_name_ip}", "127.0.0.1:443", f"--{options.opt_name_iterator}", "product",
              f"--{options.opt_name_threads}", "30", f"--{options.opt_name_sleep}", "2",
-             f"--{options.opt_name_plugin_executors}", "4",
+             f"--{options.opt_name_plugin_threads}", "4",
              f"--{options.opt_name_location}", f"--{options.opt_name_recursion}", "3",
              f"--{options.opt_name_stop_error}", f"--{options.opt_name_dry_run}",
              f"--{options.opt_name_limit_requests}", "20000", f"--{options.opt_name_request_timeout}", "40",
@@ -189,7 +189,7 @@ class OptionsTest(unittest.TestCase):
 {options.opt_name_debug_log} = "dummy_debuglog.txt"
 {options.opt_name_proxy} = ["http://127.0.0.1:8080"]
 {options.opt_name_threads} = 30
-{options.opt_name_plugin_executors} = 4
+{options.opt_name_plugin_threads} = 4
 {options.opt_name_sleep} = 2
 {options.opt_name_location} = true
 {options.opt_name_recursion} = 3
@@ -244,7 +244,7 @@ class OptionsTest(unittest.TestCase):
 {options.opt_name_debug_log} = "dummy_debuglog.txt"
 {options.opt_name_proxy} = ["http://127.0.0.1:8080"]
 {options.opt_name_threads} = 30
-{options.opt_name_plugin_executors} = 4
+{options.opt_name_plugin_threads} = 4
 {options.opt_name_sleep} = 2
 {options.opt_name_location} = true
 {options.opt_name_recursion} = 3
@@ -282,7 +282,7 @@ doesnt_exist = true
 {options.opt_name_debug_log} = "dummy_debuglog.txt"
 {options.opt_name_proxy} = ["http://127.0.0.1:8080"]
 {options.opt_name_threads} = 30
-{options.opt_name_plugin_executors} = 4
+{options.opt_name_plugin_threads} = 4
 {options.opt_name_sleep} = 2
 {options.opt_name_location} = true
 {options.opt_name_recursion} = 3
@@ -319,7 +319,7 @@ doesnt_exist = true
 {options.opt_name_debug_log} = "dummy_debuglog.txt"
 {options.opt_name_proxy} = ["http://127.0.0.1:8080"]
 {options.opt_name_threads} = 30
-{options.opt_name_plugin_executors} = 4
+{options.opt_name_plugin_threads} = 4
 {options.opt_name_sleep} = 2
 {options.opt_name_location} = true
 {options.opt_name_recursion} = 3
@@ -356,7 +356,7 @@ doesnt_exist = true
 {options.opt_name_debug_log} = "dummy_debuglog.txt"
 {options.opt_name_proxy} = ["http://127.0.0.1:8080"]
 {options.opt_name_threads} = 30
-{options.opt_name_plugin_executors} = 4
+{options.opt_name_plugin_threads} = 4
 {options.opt_name_sleep} = 2
 {options.opt_name_location} = true
 {options.opt_name_recursion} = 3
@@ -393,7 +393,7 @@ doesnt_exist = true
 {options.opt_name_debug_log} = "dummy_debuglog.txt"
 {options.opt_name_proxy} = ["http://127.0.0.1:8080"]
 {options.opt_name_threads} = 30
-{options.opt_name_plugin_executors} = 4
+{options.opt_name_plugin_threads} = 4
 {options.opt_name_sleep} = 2
 {options.opt_name_location} = true
 {options.opt_name_recursion} = 3


### PR DESCRIPTION
…ecutors refers to the class name, but there is a separate thread for each class instance nayways, and the term "thread" should be more intuitive to the user