### PR TITLE
move sleep to Http queue 

### DIFF
--- a/src/wenum/fuzzqueues.py
+++ b/src/wenum/fuzzqueues.py
@@ -45,7 +45,6 @@ class SeedQueue(FuzzQueue):
 
     def __init__(self, session: FuzzSession):
         super().__init__(session)
-        self.sleep = session.options.sleep
 
     def get_name(self):
         return "SeedQueue"
@@ -136,8 +135,6 @@ class SeedQueue(FuzzQueue):
             while fuzz_word:
                 if self.session.compiled_stats.cancelled:
                     break
-                if self.sleep:
-                    time.sleep(self.sleep)
                 fuzz_result = self.get_fuzz_res(fuzz_word)
                 # Only send out if it's not already in the cache
                 if not self.session.cache.check_cache(fuzz_result.url):

--- a/src/wenum/myhttp.py
+++ b/src/wenum/myhttp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Optional
 from urllib.parse import urlparse
 
@@ -53,6 +54,7 @@ class HttpPool:
         # Queue object storing all the requests available for sending out. Maxsize avoids buffering tens of thousands of
         # requests beforehand, which would result in gigabytes of reserved memory
         self.request_queue: Queue = Queue(maxsize=session.options.threads)
+        self.sleep = session.options.sleep
 
         # List containing the threads
         # TODO This list seems to only contain a single thread. Refactor into a single thread attribute?
@@ -282,6 +284,9 @@ class HttpPool:
                 ret, num_handles = self.curl_multi.perform()
                 if ret != pycurl.E_CALL_MULTI_PERFORM:
                     break
+
+            if self.sleep > 0:
+                time.sleep(self.sleep)
 
             num_q, ok_list, err_list = self.curl_multi.info_read()
 


### PR DESCRIPTION
Move sleep to Http queue before actually making a requests, this avoi…ds bypassing the sleep from requests made by plugins and speeds up cached requests as they don't have to sleep