### PR TITLE
check if cache file exists before trying to read it

### DIFF
--- a/src/wenum/externals/reqresp/cache.py
+++ b/src/wenum/externals/reqresp/cache.py
@@ -57,7 +57,10 @@ class HttpCache:
         if not os.path.isdir(directory):
             return
         self.cache_dir = directory
-        with open(os.path.join(directory, "cache.json"), "rb") as cache_data:
+        cache_file = os.path.join(directory, "cache.json")
+        if not os.path.isfile(cache_file):
+            return
+        with open(cache_file, "rb") as cache_data:
             self.__cache_dir_map = json.load(cache_data)
 
     def _fuzz_result_from_cache(self, key: str, fuzz_result: FuzzResult) -> FuzzResult | None:


### PR DESCRIPTION
This checks if the file exists, otherwise wenum may fail to start if the directory exists but not the `cache.json`


---
The program was tested solely for our own use cases, which might differ from yours.

Florian Pfitzer <florian.pfitzer@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)

Licensed under GPL 2.0

