### PR TITLE
cache might not be initialized correctly and crash wfuzz

### DIFF
--- a/src/wenum/externals/reqresp/cache.py
+++ b/src/wenum/externals/reqresp/cache.py
@@ -13,7 +13,7 @@ class HttpCache:
     The cache keeps track of all the requests that have already been enqueued, to avoid doing it multiple times.
     """
     cache_dir = None
-    __cache_dir_map = None
+    __cache_dir_map = {}
 
     def __init__(self, cache_dir: Optional[str] = None):
         # cache control, a dictionary with URLs as keys and their values being lists full of the
@@ -56,10 +56,10 @@ class HttpCache:
     def load_cache_dir(self, directory: str) -> None:
         if not os.path.isdir(directory):
             return
-        self.cache_dir = directory
         cache_file = os.path.join(directory, "cache.json")
         if not os.path.isfile(cache_file):
             return
+        self.cache_dir = directory
         with open(cache_file, "rb") as cache_data:
             self.__cache_dir_map = json.load(cache_data)
 


### PR DESCRIPTION
cache might not be initialized correctly and crash wfuzz. So set cache_dir only when all files exists.

---
The program was tested solely for our own use cases, which might differ from yours.

Florian Pfitzer <florian.pfitzer@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

Licensed under GPL 2.0
